### PR TITLE
Synchronize usage example with diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install emic2
 ##Initiating module
 ```js
 var tessel = require('tessel');
-var emic2 = require('emic2').use(tessel.port['A']);
+var emic2 = require('emic2').use(tessel.port['D']);
 
 emic2.on('ready', function(){
     emic2.speak('Hello, this is Tessel, your new friend');


### PR DESCRIPTION
Usage example and and diagram are both awesome, but the diagram shows the Emic2 hooked up to port D while the usage example uses port A. Not a huge deal, but it might trip up readers who blindly follow directions without reading too carefully ;)
